### PR TITLE
Increase control frequency.

### DIFF
--- a/mujoco_ros2_control/src/mujoco_ros2_control_node.cpp
+++ b/mujoco_ros2_control/src/mujoco_ros2_control_node.cpp
@@ -99,7 +99,7 @@ int main(int argc, const char **argv)
   auto last_control_update = std::chrono::steady_clock::now();
   auto last_render_update = std::chrono::steady_clock::now();
   auto last_cam_update = std::chrono::steady_clock::now();
-  constexpr double CONTROL_FREQ = 100.0;
+  constexpr double CONTROL_FREQ = 1000.0;
   constexpr double RENDER_FREQ = 30.0;
   constexpr double CAMERA_FREQ = 5.0;
 


### PR DESCRIPTION
Movement duration for a goto command of 1s was about 2.7s before this change, whereas 1.4s now.

Tested with this script : 
```python
from reachy2_sdk import ReachySDK
import time
import numpy as np

#connect to the robot
reachy = ReachySDK('localhost')
wait_durations = []
mvt_durations = []

for i in range(5):
    t0 = time.time()
    reachy.goto_posture('elbow_90', wait = True, duration =1)
    wait_durations.append(time.time() - t0)
    print("end of waiting at ", time.time() - t0)
    while reachy.r_arm.elbow.pitch.present_position >= -85 :
        time.sleep(0.01)
    mvt_durations.append(time.time() - t0)
    print("end of mvt at ", time.time() - t0)


    reachy.goto_posture()
    while reachy.r_arm.elbow.pitch.present_position <= -5 :
        time.sleep(0.01)

mean_wait = np.mean(wait_durations)
mean_mvt = np.mean(mvt_durations)
print(f"Median wait duration: {mean_wait:.2f} seconds"
      f"\nMedian movement duration: {mean_mvt:.2f} seconds")
```